### PR TITLE
Hwxrtao/allow url options to take inputs

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -27,7 +27,7 @@ module ActionController
 
     include AbstractController::UrlFor
 
-    def url_options
+    def url_options(inner_options: nil)
       @_url_options ||= {
         host: request.host,
         port: request.optional_port,

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -258,7 +258,7 @@ module ActionDispatch
           end
 
           def call(t, method_name, args, inner_options, url_strategy)
-            controller_options = t.url_options
+            controller_options = t.url_options(inner_options: inner_options)
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
                                           inner_options || {},
@@ -536,7 +536,7 @@ module ActionDispatch
             end
 
             def _routes; @_proxy._routes; end
-            def url_options; {}; end
+            def url_options(inner_options: nil); {}; end
           end
 
           url_helpers = routes.named_routes.url_helpers_module

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -16,7 +16,7 @@ module ActionDispatch
         @script_namer = script_namer
       end
 
-      def url_options
+      def url_options(inner_options: nil)
         scope.send(:_with_routes, routes) do
           scope.url_options
         end

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -96,8 +96,6 @@ module ActionDispatch
           else
             mattr_writer :default_url_options
           end
-
-          self.default_url_options = {}
         end
 
         include(*_url_for_modules) if respond_to?(:_url_for_modules)
@@ -106,6 +104,10 @@ module ActionDispatch
       def initialize(...)
         @_routes = nil
         super
+      end
+
+      def default_url_options(options: nil)
+        {}
       end
 
       # Hook overridden in controller to add request information

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -111,8 +111,8 @@ module ActionDispatch
       # Hook overridden in controller to add request information
       # with +default_url_options+. Application logic should not
       # go into url_options.
-      def url_options
-        default_url_options
+      def url_options(inner_options: nil)
+        default_url_options(options: inner_options)
       end
 
       # Generate a URL based on the options provided, default_url_options and the

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -165,7 +165,7 @@ module ActionDispatch
               include ActionDispatch.test_app.routes.url_helpers
               include ActionDispatch.test_app.routes.mounted_helpers
 
-              def url_options
+              def url_options(inner_options: nil)
                 default_url_options.reverse_merge(host: Capybara.app_host || Capybara.current_session.server_url)
               end
             end.new

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -130,7 +130,7 @@ module ActionDispatch
         reset!
       end
 
-      def url_options
+      def url_options(inner_options: nil)
         @url_options ||= default_url_options.dup.tap do |url_options|
           url_options.reverse_merge!(controller.url_options) if controller.respond_to?(:url_options)
 
@@ -633,7 +633,7 @@ module ActionDispatch
 
     module UrlOptions
       extend ActiveSupport::Concern
-      def url_options
+      def url_options(inner_options: nil)
         integration_session.url_options
       end
     end

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -50,7 +50,7 @@ class UrlOptionsController < ActionController::Base
     render inline: "<%= #{params[:route]} %>"
   end
 
-  def url_options
+  def url_options(inner_options: nil)
     super.merge(host: "www.override.com")
   end
 end

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -118,7 +118,7 @@ module ActionView
       end
     end
 
-    def url_options #:nodoc:
+    def url_options(inner_options: nil) #:nodoc:
       return super unless controller.respond_to?(:url_options)
       controller.url_options
     end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -13,7 +13,7 @@ class FormHelperTest < ActionView::TestCase
       post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
     end
 
-    def url_options
+    def url_options(inner_options: nil)
       { host: "testtwo.host" }
     end
   end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -12,7 +12,7 @@ class FormTagHelperTest < ActionView::TestCase
       post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
     end
 
-    def url_options
+    def url_options(inner_options: nil)
       { host: "testtwo.host" }
     end
   end


### PR DESCRIPTION
### Summary

Currently `url_options` and `default_url_options` do not take any input argument. As a result, when `url_options` gets called in `route_set.rb`, there is no way for `inner_options` to be passed down to `url_options` and subsequently to `default_url_options`. 

On the other hand, `default_url_options` is typically overridden in application controller to add request information. There may be circumstances where the application wants to pass information to `default_url_options` in order to generate the desired outcome, but because of the fact stated above, it is impossible to do so.

This draft PR is an attempt to open up `url_options` and `default_url_options` to accept input argument.